### PR TITLE
[lineage-17.1] Fix missed touch events

### DIFF
--- a/drivers/pinctrl/qcom/pinctrl-msm.c
+++ b/drivers/pinctrl/qcom/pinctrl-msm.c
@@ -596,39 +596,6 @@ static void msm_gpio_irq_mask(struct irq_data *d)
 		pctrl->irq_chip_extn->irq_mask(d);
 }
 
-static void msm_gpio_irq_enable(struct irq_data *d)
-{
-	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
-	struct msm_pinctrl *pctrl = to_msm_pinctrl(gc);
-	const struct msm_pingroup *g;
-	unsigned long flags;
-	u32 val;
-
-	g = &pctrl->soc->groups[d->hwirq];
-
-	spin_lock_irqsave(&pctrl->lock, flags);
-	/* clear the interrupt status bit before unmask to avoid
-	 * any erroneous interrupts that would have got latched
-	 * when the interrupt is not in use.
-	 */
-	val = readl_relaxed(pctrl->regs + g->intr_status_reg);
-	if (g->intr_ack_high)
-		val |= BIT(g->intr_status_bit);
-	else
-		val &= ~BIT(g->intr_status_bit);
-	writel_relaxed(val, pctrl->regs + g->intr_status_reg);
-
-	val = readl_relaxed(pctrl->regs + g->intr_cfg_reg);
-	val |= BIT(g->intr_enable_bit);
-	writel_relaxed(val, pctrl->regs + g->intr_cfg_reg);
-
-	set_bit(d->hwirq, pctrl->enabled_irqs);
-
-	spin_unlock_irqrestore(&pctrl->lock, flags);
-	if (pctrl->irq_chip_extn->irq_enable)
-		pctrl->irq_chip_extn->irq_enable(d);
-}
-
 static void msm_gpio_irq_unmask(struct irq_data *d)
 {
 	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
@@ -799,7 +766,6 @@ static int msm_gpio_irq_set_wake(struct irq_data *d, unsigned int on)
 static struct irq_chip msm_gpio_irq_chip = {
 	.name           = "msmgpio",
 	.flags          = IRQCHIP_MASK_ON_SUSPEND,
-	.irq_enable     = msm_gpio_irq_enable,
 	.irq_mask       = msm_gpio_irq_mask,
 	.irq_unmask     = msm_gpio_irq_unmask,
 	.irq_ack        = msm_gpio_irq_ack,


### PR DESCRIPTION
This causes missed touch events for our devices, most often when there is an approximate 2s gap between subsequent touches.