### PR TITLE
Further reduce initial screen brightness

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8998-yoshino-common.dtsi
@@ -3625,7 +3625,7 @@
 	linux,name = "wled";
 	qcom,fs-curr-ua = <24000>;
 	qcom,led-strings-list = [00 01 02];
-	somc,init-br-ua = <1200>;
+	somc,init-br-ua = <800>;
 	somc-s1,br-power-save-ua = <800>;
 	somc,bl-scale-enabled;
 	somc,area_count_table_size = <0>;


### PR DESCRIPTION
Use the power-save value because the boot-up screen is almost full white for most SONY phones so the initial brightness is perceived even higher.

Cherry-pick from my branch. Please merge as "rebase" if possible to reduce divergence of the branches.