### PR TITLE
QCom display driver backport from ASB 2022-04-01

### DIFF
--- a/drivers/gpu/drm/msm/msm_drv.c
+++ b/drivers/gpu/drm/msm/msm_drv.c
@@ -1851,7 +1851,7 @@ static int msm_ioctl_submitqueue_close(struct drm_device *dev, void *data,
 
 int msm_release(struct inode *inode, struct file *filp)
 {
-	struct drm_file *file_priv = filp->private_data;
+	struct drm_file *file_priv;
 	struct drm_minor *minor;
 	struct drm_device *dev;
 	struct msm_drm_private *priv;
@@ -1861,6 +1861,7 @@ int msm_release(struct inode *inode, struct file *filp)
 
 	mutex_lock(&msm_release_lock);
 
+	file_priv = filp->private_data;
 	if (!file_priv) {
 		ret = -EINVAL;
 		goto end;


### PR DESCRIPTION
Fix for CVE-2021-30334 backported from the QCom repos

Upstream commits: https://source.codeaurora.org/quic/le/platform/vendor/opensource/display-drivers/commit/?id=3d8c6200be552fd63de67261d78e62a6eb8a689b and https://source.codeaurora.org/quic/le/platform/vendor/opensource/display-drivers/commit/?id=070934308cd58693ee33f782facf69e5be0e0f02

I manually applied the changes as it would otherwise need conflict resolution. However I kept the original commit message and author