### PR TITLE
Fix for CVE-2022-1786

### DIFF
--- a/sound/soc/msm/qdsp6v2/msm-pcm-routing-v2.c
+++ b/sound/soc/msm/qdsp6v2/msm-pcm-routing-v2.c
@@ -1476,16 +1476,20 @@ static int msm_pcm_routing_channel_mixer_v2(int fe_id, bool perf_mode,
 		return 0;
 	}
 
-	pr_debug("%s sess type %d fe_id %d override %d be active %d\n",
-			__func__,
-			sess_type,
-			fe_id,
-			channel_mixer_v2[fe_id][sess_type].override_cfg,
-			msm_bedais[be_id].active);
 	if (channel_mixer_v2[fe_id][sess_type].override_cfg) {
 		be_id = channel_mixer_v2[fe_id][sess_type].port_idx - 1;
+		if (be_id < 0 || be_id >= MSM_BACKEND_DAI_MAX) {
+			pr_err("%s: Received out of bounds be_id %d\n",
+					__func__, be_id);
+			return -EINVAL;
+		}
 		channel_mixer_v2[fe_id][sess_type].input_channels[0] =
 			channel_mixer_v2[fe_id][sess_type].input_channel;
+
+		pr_debug("%s sess type %d fe_id %d override %d be active %d\n",
+				__func__, sess_type, fe_id,
+				channel_mixer_v2[fe_id][sess_type].override_cfg,
+				msm_bedais[be_id].active);
 
 		if ((msm_bedais[be_id].active) &&
 			test_bit(fe_id,


### PR DESCRIPTION
This is from the latest ASB: https://source.android.com/security/bulletin/2022-08-01#qualcomm-components

I also moved the debug print to the place where it belongs to not use a wrong beid.

BTW: What was the reason we stick to the 4.4 kernel and not upgrade to a newer one? Is that (easily) possible (e.g. by a merge)?