### PR TITLE
Remove duplicated `__bpf_prog_charge`/`__bpf_prog_uncharge`

### DIFF
--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -386,6 +386,7 @@ static inline struct bpf_prog *bpf_prog_get_type(u32 ufd,
 static inline void bpf_prog_put(struct bpf_prog *prog)
 {
 }
+
 static inline struct bpf_prog *bpf_prog_inc(struct bpf_prog *prog)
 {
 	return ERR_PTR(-EOPNOTSUPP);
@@ -409,14 +410,6 @@ static inline struct bpf_prog *bpf_prog_get_type_path(const char *name,
 				enum bpf_prog_type type)
 {
 	return ERR_PTR(-EOPNOTSUPP);
-
-static inline int __bpf_prog_charge(struct user_struct *user, u32 pages)
-{
-	return 0;
-}
-
-static inline void __bpf_prog_uncharge(struct user_struct *user, u32 pages)
-{
 }
 
 static inline bool unprivileged_ebpf_enabled(void)


### PR DESCRIPTION
See https://github.com/whatawurst/android_kernel_sony_msm8998/pull/84/files#diff-10c25cae50af6c8c81a80025da7200c8afa166f20c0b39bc85a745b9105f8ce6R395-R402

They likely originated from a merge conflict resolution.

Also add a missing newline and closing brace.

Only has an effect when `CONFIG_BPF_SYSCALL` is NOT set.